### PR TITLE
Fix invalid protobuf messages and restructure Persona

### DIFF
--- a/persona.proto
+++ b/persona.proto
@@ -16,6 +16,16 @@ message Persona {
 
   bytes private_key = 5;
 
+  /*
+  * Unique byte string representing the Persona
+  */
+  bytes uid = 6;
+
+  /*
+  * Used to optionally mutate the uid
+  */
+  bytes mask = 7;
+
   message all_peers {
     repeated Peer peer = 1;
   }

--- a/persona.proto
+++ b/persona.proto
@@ -41,9 +41,13 @@ message Persona {
     repeated Peer peer = 1;
   }
 
-  bool peer = 6;
+  bool owned = 8;
 }
 
-message secret_book{
-  repeated persona person = 1;
+/*
+ * Used to store all user owned personas and known peer personas
+ */
+message Wallet {
+  repeated Persona my_personas = 1;
+  repeated Persona peer_personas = 2;
 }

--- a/persona.proto
+++ b/persona.proto
@@ -1,9 +1,13 @@
 syntax = "proto3";
 
-// This protobuf is for adding public/private key pairs to the messaging.
+/*
+ * Stores information about an identity.
+ * This identity can be the user themself or a peer node.
+ * Used for digital signatures in the Black Lager messaging application.
+ */
 message Persona {
   /*
-  * Unique Local Name
+  * Unique local Persona name
   */
   string local_name = 1;
 
@@ -37,10 +41,10 @@ message Persona {
    */
   bytes mask = 7;
 
-  message all_peers {
-    repeated Peer peer = 1;
-  }
-
+  /*
+   * True if the user owns this persona
+   * False if this is a peer persona
+   */
   bool owned = 8;
 }
 

--- a/persona.proto
+++ b/persona.proto
@@ -2,27 +2,27 @@ syntax = "proto3";
 
 // This protobuf is for adding public/private key pairs to the messaging.
 message Persona {
-    /*
-    *   Unique Local Name
-    */
-    string local_name = 1;
-    string mac_address = 2;
-    int32 node_num = 3;
+  /*
+  * Unique Local Name
+  */
+  string local_name = 1;
+  string mac_address = 2;
+  int32 node_num = 3;
 
-    /*
-    *   Self's public and private key
-    */
-    bytes public_key = 4;
+  /*
+  * Self's public and private key
+  */
+  bytes public_key = 4;
 
-    bytes private_key = 5;
+  bytes private_key = 5;
 
-    message all_peers {
-        repeated Peer peer = 1;
-    }
+  message all_peers {
+    repeated Peer peer = 1;
+  }
 
-    bool peer = 6;
+  bool peer = 6;
 }
 
 message secret_book{
-    repeated persona person = 1;
+  repeated persona person = 1;
 }

--- a/persona.proto
+++ b/persona.proto
@@ -6,24 +6,35 @@ message Persona {
   * Unique Local Name
   */
   string local_name = 1;
+
+  /*
+   * Device MAC address
+   */
   string mac_address = 2;
+
+  /*
+   * Device node number
+   */
   int32 node_num = 3;
 
   /*
-  * Self's public and private key
+  * Used for local owned Persona and peer Personas
   */
   bytes public_key = 4;
 
+  /*
+   * Only used if this is a local owned Persona
+   */
   bytes private_key = 5;
 
   /*
-  * Unique byte string representing the Persona
-  */
+   * Unique byte string representing the Persona
+   */
   bytes uid = 6;
 
   /*
-  * Used to optionally mutate the uid
-  */
+   * Used to optionally mutate the uid
+   */
   bytes mask = 7;
 
   message all_peers {


### PR DESCRIPTION
Close #4 

Fixed a typo which made the protobuf message invalid.
Restructured the Persona message to move the repeated Persona field to a wallet.
Added documentation for every field in the protobuf.